### PR TITLE
remove m2r dependency, add markdown support for pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ markdown>=2.6.11
 markdown-full-yaml-metadata>=0.0.2
 Pygments>=2.2.0
 pytest>=3.4.1
-m2r>=0.1.14
+#m2r>=0.1.14
 pytest-cov>=2.5.1
 coveralls>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup, find_packages
 from os import path
-from m2r import convert
 
 
 currdir = path.abspath(path.dirname(__file__))
@@ -26,7 +25,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     long_description=long_desc,
-    long_description_content_type='text/markdown'
+    long_description_content_type='text/markdown',
     python_requires='>=3',
     install_requires=[
           'flask',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from m2r import convert
 currdir = path.abspath(path.dirname(__file__))
 with open(path.join(currdir, 'README.md')) as f:
     long_desc = f.read()
-long_rst_desc = convert(long_desc)
+#long_rst_desc = convert(long_desc)
+
 setup(
     name='Blask',
     version='0.1.0b8',
@@ -24,14 +25,15 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
-    long_description=long_rst_desc,
+    long_description=long_desc,
+    long_description_content_type='text/markdown'
     python_requires='>=3',
     install_requires=[
           'flask',
           'markdown',
           'markdown-full-yaml-metadata',
           'Pygments',
-          'm2r'
+          #'m2r'
     ],
     test_require=[
         'pytest',


### PR DESCRIPTION
You can add suppport for Markdown on PyPI with

    long_description_content_type='text/markdown'

Removed `m2r` from `requirements.txt` and `setup.py`

Now should work fine. Tested and install correctly.