### PR TITLE
Using different path manager and including Visual Studio Code and Mac OS in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,10 @@ ENV/
 # callsonar
 
 callsonarblask.bat
+
+# visual studio code and sonarlint extension
+.vscode/
+.sonarlint/
+
+# Mac OS X
+.DS_Store

--- a/Blask/blaskapp.py
+++ b/Blask/blaskapp.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from flask import Flask, render_template,request
+from flask import Flask, render_template, request
 from Blask.blasksettings import BlaskSettings
 from Blask.blogrenderer import BlogRenderer
 from Blask.errors import PageNotExistError
@@ -35,13 +35,21 @@ class BlaskApp:
     def __init__(self, **kwargs):
         self.settings = BlaskSettings(**kwargs)
         self.blogrenderer = BlogRenderer(self.settings['postDir'])
-        self.app = Flask(__name__, template_folder=self.settings['templateDir'], static_folder=self.settings['staticDir'])
-        self.app.add_url_rule('/', endpoint='index', view_func=self._index, methods=['GET'])
-        self.app.add_url_rule('/<filename>', view_func=self._getpage, methods=['GET'])
-        self.app.add_url_rule('/tag/<tag>', view_func=self._gettag, methods=['GET'])
-        self.app.add_url_rule('/search', view_func=self.searchpages, methods=['POST'])
-        self.app.add_url_rule('/category/<category>', view_func=self._getcategory, methods=['GET'])
-        self.app.add_url_rule('/author/<author>', view_func=self._getauthor, methods=['GET'])
+        self.app = Flask(__name__,
+                         template_folder=self.settings['templateDir'],
+                         static_folder=self.settings['staticDir'])
+        self.app.add_url_rule('/', endpoint='index', view_func=self._index,
+                              methods=['GET'])
+        self.app.add_url_rule('/<filename>', view_func=self._getpage,
+                              methods=['GET'])
+        self.app.add_url_rule('/tag/<tag>', view_func=self._gettag,
+                              methods=['GET'])
+        self.app.add_url_rule('/search', view_func=self.searchpages,
+                              methods=['POST'])
+        self.app.add_url_rule('/category/<category>',
+                              view_func=self._getcategory, methods=['GET'])
+        self.app.add_url_rule('/author/<author>', view_func=self._getauthor,
+                              methods=['GET'])
 
     def _index(self):
         """
@@ -52,7 +60,8 @@ class BlaskApp:
         template = entry.template
         if template is None:
             template = self.settings['defaultLayout']
-        return render_template(template, title=self.settings['title'], content=entry.content)
+        return render_template(template, title=self.settings['title'],
+                               content=entry.content)
 
     def _getpage(self, filename):
         """
@@ -72,7 +81,8 @@ class BlaskApp:
         author = entry.author
         if template is None:
             template = self.settings['defaultLayout']
-        return render_template(template, title=self.settings['title'], content=content, date=date, tags=tags,
+        return render_template(template, title=self.settings['title'],
+                               content=content, date=date, tags=tags,
                                category=category, author=author)
 
     def _gettag(self, tag):
@@ -83,7 +93,8 @@ class BlaskApp:
         """
         postlist = self.blogrenderer.list_posts([tag])
         content = self.blogrenderer.generatetagpage(postlist)
-        return render_template(self.settings['defaultLayout'], title=self.settings['title'], content=content)
+        return render_template(self.settings['defaultLayout'],
+                               title=self.settings['title'], content=content)
 
     def searchpages(self):
         """
@@ -92,7 +103,8 @@ class BlaskApp:
         """
         postlist = self.blogrenderer.list_posts(search=request.form['search'])
         content = self.blogrenderer.generatetagpage(postlist)
-        return render_template(self.settings['defaultLayout'], title=self.settings['title'], content=content)
+        return render_template(self.settings['defaultLayout'],
+                               title=self.settings['title'], content=content)
 
     def _getcategory(self, category):
         """
@@ -102,7 +114,8 @@ class BlaskApp:
         """
         postlist = self.blogrenderer.list_posts(category=category)
         content = self.blogrenderer.generatetagpage(postlist)
-        return render_template(self.settings['defaultLayout'], title=self.settings['title'], content=content)
+        return render_template(self.settings['defaultLayout'],
+                               title=self.settings['title'], content=content)
 
     def _getauthor(self, author):
         """
@@ -112,9 +125,8 @@ class BlaskApp:
         """
         postlist = self.blogrenderer.list_posts(author=author)
         content = self.blogrenderer.generatetagpage(postlist)
-        return render_template(self.settings['defaultLayout'], title=self.settings['title'], content=content)
-
-
+        return render_template(self.settings['defaultLayout'],
+                               title=self.settings['title'], content=content)
 
     def run(self, **kwargs):
         self.app.run(**kwargs)

--- a/Blask/blasksettings.py
+++ b/Blask/blasksettings.py
@@ -18,15 +18,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+from pathlib import Path
 import logging
 
-BASE_DIR = os.getcwd()
+BASE_DIR = Path(__file__).resolve().parents[0]
 
 DEFAULT_SETTINGS = {
-    'templateDir': os.path.join(BASE_DIR, 'templates'),
-    'postDir': os.path.join(BASE_DIR, 'posts'),
+    'templateDir': BASE_DIR / 'templates',
+    'postDir': BASE_DIR / 'posts',
     'defaultLayout': 'template.html',
-    'staticDir': os.path.join(BASE_DIR, 'static'),
+    'staticDir': BASE_DIR / 'static',
     'title': 'Blask | A Simple Blog Engine Based on Flask'
 }
 

--- a/Blask/blasksettings.py
+++ b/Blask/blasksettings.py
@@ -21,13 +21,13 @@ import os
 from pathlib import Path
 import logging
 
-BASE_DIR = Path(__file__).resolve().parents[0]
+BASE_DIR = Path(__file__).resolve().parents[1]
 
 DEFAULT_SETTINGS = {
-    'templateDir': BASE_DIR / 'templates',
-    'postDir': BASE_DIR / 'posts',
-    'defaultLayout': 'template.html',
-    'staticDir': BASE_DIR / 'static',
+    'templateDir': str(BASE_DIR / 'templates'),
+    'postDir': str(BASE_DIR / 'posts'),
+    'defaultLayout': str('template.html'),
+    'staticDir': str(BASE_DIR / 'static'),
     'title': 'Blask | A Simple Blog Engine Based on Flask'
 }
 
@@ -41,12 +41,8 @@ class BlaskSettings(object):
         # Check environment variable for settings module
         if 'BLASK_SETTINGS' in os.environ:
             # Load settings from the module in environment variable
-            settings_mod = __import__(
-                os.environ['BLASK_SETTINGS'],
-                globals(),
-                locals(),
-                ['object'],
-                0)
+            settings_mod = __import__(os.environ['BLASK_SETTINGS'], globals(),
+                                      locals(), ['object'], 0)
             self.settings = {}
             for key in DEFAULT_SETTINGS.keys():
                 value = getattr(settings_mod, key, DEFAULT_SETTINGS[key])

--- a/Blask/blogrenderer.py
+++ b/Blask/blogrenderer.py
@@ -26,7 +26,8 @@ from functools import lru_cache
 
 class BlogRenderer:
     """
-    Class BlogRenderer: This class provides the feature for render posts from Markdown to HTML and search features.
+    Class BlogRenderer: This class provides the feature for render posts from
+    Markdown to HTML and search features.
     :Author: Zerasul <suarez.garcia.victor@gmail.com>
     Date: 2018-05-05
     Version: 0.1.0
@@ -35,12 +36,10 @@ class BlogRenderer:
     """
     Posts Directory
     """
-
     cache = {}
     """
     Post Cache; improves the post loading.
     """
-
     def __init__(self, postdir):
         """
         This is the constructor of the blog renderer.
@@ -51,7 +50,8 @@ class BlogRenderer:
     def renderfile(self, filename):
         """
             Render a markdown and returns the blogEntry.
-            Note: This method uses a cache based on a SHA-256 hash of the content.
+            Note: This method uses a cache based on a SHA-256 hash of the
+            content.
         :param filename: Number of the file without extension.
         :return: BlogEntry.
         :raises PageNotExistError Raise this error if file does not exists.
@@ -80,7 +80,8 @@ class BlogRenderer:
         entry = BlogEntry(filename, md, text)
         return entry
 
-    def list_posts(self, tags=[], exclusions=["index.md", "404.md"], search="", category="", author=""):
+    def list_posts(self, tags=[], exclusions=["index.md", "404.md"], search="",
+                   category="", author=""):
         """
         Search a list of Posts returning a list of BlogEntry.
         :param tags: list of tags for searching.
@@ -90,7 +91,8 @@ class BlogRenderer:
         :param author: name of the author of the post
         :return: List of BlogEntry.
         """
-        files = list(filter(lambda l: l.endswith('.md') and l not in exclusions, listdir(self.postdir)))
+        files = list(filter(lambda l: l.endswith('.md') and l not in
+                            exclusions, listdir(self.postdir)))
         mapfilter = list(map(lambda l: path.splitext(l)[0], files))
         entries = list(map(lambda l: self.renderfile(l), mapfilter))
         if tags:
@@ -113,7 +115,8 @@ class BlogRenderer:
         """
         content = '<ul>'
         for post in postlist:
-            entrycontent = "<li><a href='/{}'>{}</a></li>".format(post.name, post.name)
+            entrycontent = "<li><a href='/{}'>{}</a></li>".format(post.name,
+                                                                  post.name)
             content += entrycontent
         content += "</ul>"
         return content
@@ -161,5 +164,10 @@ class BlogEntry:
                 self.author = meta['author'][0]
 
     def __str__(self):
-        string = "['content': {}, 'name': {}, 'date': {}, 'tags':[{}], 'author': {}, 'category': {}, template': {}]".format(self.content,self.name,self.date,self.tags,self.author,self.category,self.template)
+        string = "['content': {}, 'name': {}, ".format(self.content, self.name)
+        string += "'date': {}, 'tags':[{}], ".format(self.date, self.tags)
+        string += "'author': {}, 'category': {}, ".format(self.author,
+                                                          self.category)
+        string += "'template': {}]".format(self.template)
+
         return string

--- a/Blask/errors.py
+++ b/Blask/errors.py
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
+
+
 class PageNotExistError(Exception):
     def __init__(self, message):
         super(PageNotExistError, self).__init__(message)

--- a/main.py
+++ b/main.py
@@ -11,11 +11,9 @@ if __name__ == '__main__':
     parser.add_argument(
         "-v", "--verbose", action='store_true', help="Verbose output")
     args = parser.parse_args()
-
-
     if args.debug or args.verbose:
         log = logging.getLogger()
-        level = logging.getLevelName('DEBUG')
+        level = logging.getLevelName(logging.DEBUG)
         log.setLevel(level)
         debug = True
     else:

--- a/settings.py
+++ b/settings.py
@@ -1,22 +1,17 @@
-import os
 from pathlib import Path
 
-#BASE_DIR = os.getcwd()
 BASE_DIR = Path(__file__).resolve().parents[0]
 
 # Templates directory
-#templateDir = os.path.join(BASE_DIR, 'templates')
 templateDir = BASE_DIR / 'templates'
 
 # Posts directory
-#postDir = os.path.join(BASE_DIR, 'posts')
 postDir = BASE_DIR / 'posts'
 
 # Default layout template
 defaultLayout = "template.html"
 
 # Static files directory
-#staticDir = os.path.join(BASE_DIR, 'static')
 staticDir = BASE_DIR / 'static'
 
 # Website title

--- a/settings.py
+++ b/settings.py
@@ -1,18 +1,23 @@
 import os
+from pathlib import Path
 
-BASE_DIR = os.getcwd()
+#BASE_DIR = os.getcwd()
+BASE_DIR = Path(__file__).resolve().parents[0]
 
 # Templates directory
-templateDir = os.path.join(BASE_DIR, 'templates')
+#templateDir = os.path.join(BASE_DIR, 'templates')
+templateDir = BASE_DIR / 'templates'
 
 # Posts directory
-postDir = os.path.join(BASE_DIR, 'posts')
+#postDir = os.path.join(BASE_DIR, 'posts')
+postDir = BASE_DIR / 'posts'
 
 # Default layout template
 defaultLayout = "template.html"
 
 # Static files directory
-staticDir = os.path.join(BASE_DIR, 'static')
+#staticDir = os.path.join(BASE_DIR, 'static')
+staticDir = BASE_DIR / 'static'
 
 # Website title
 title = 'Blask | A Simple Blog Engine Based on Flask'

--- a/settings.py
+++ b/settings.py
@@ -3,16 +3,16 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parents[0]
 
 # Templates directory
-templateDir = BASE_DIR / 'templates'
+templateDir = str(BASE_DIR / 'templates')
 
 # Posts directory
-postDir = BASE_DIR / 'posts'
+postDir = str(BASE_DIR / 'posts')
 
 # Default layout template
 defaultLayout = "template.html"
 
 # Static files directory
-staticDir = BASE_DIR / 'static'
+staticDir = str(BASE_DIR / 'static')
 
 # Website title
 title = 'Blask | A Simple Blog Engine Based on Flask'

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
-from os import path
+from pathlib import Path
 
-
-currdir = path.abspath(path.dirname(__file__))
-with open(path.join(currdir, 'README.md')) as f:
+currdir = Path(__file__).resolve().parents[0]
+file_to_open = 'README.md'
+with open(currdir / file_to_open) as f:
     long_desc = f.read()
 #long_rst_desc = convert(long_desc)
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-currdir = Path(__file__).resolve().parents[0]
-file_to_open = 'README.md'
-with open(currdir / file_to_open) as f:
+info_file = Path(__file__).resolve().parents[0] / 'README.md'
+with info_file.open() as f:
     long_desc = f.read()
-#long_rst_desc = convert(long_desc)
 
 setup(
     name='Blask',

--- a/tests/blogrender_test.py
+++ b/tests/blogrender_test.py
@@ -18,7 +18,6 @@ class TestblogRender:
         entry = self.blogrender.renderfile("index")
         assert entry.name == "index"
 
-
     def test_tagslist(self):
         entries = self.blogrender.list_posts(["blask"])
         assert len(entries) == 1

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -9,8 +9,10 @@ class TestMain:
 
     @fixture(autouse=True)
     def inittest(self):
-        b = BlaskApp(templateDir=settings.templateDir, postDir=settings.postDir, defaultLayout=settings.defaultLayout,
-                  staticDir=settings.staticDir, title=settings.title)
+        b = BlaskApp(templateDir=settings.templateDir,
+                     postDir=settings.postDir,
+                     defaultLayout=settings.defaultLayout,
+                     staticDir=settings.staticDir, title=settings.title)
         b.app.testing = True
         self.testClient = b.app.test_client()
 

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -13,7 +13,7 @@ class TestBlaskSettings:
             assert settings[kw] == blasksettings.DEFAULT_SETTINGS[kw]
 
     def test_from_environ(self):
-        os.environ['BLASK_SETTINGS'] = 'testsettings' #changed for the new version of pytest.
+        os.environ['BLASK_SETTINGS'] = 'testsettings'  # changed for new pytest
         settings = BlaskSettings()
         for kw in blasksettings.DEFAULT_SETTINGS.keys():
             if kw == 'postDir':
@@ -26,7 +26,7 @@ class TestBlaskSettings:
 
     def test_kwargs(self):
         kwsettings = {
-            'postDir': os.path.join(os.getcwd(),'mantispostdir'),
+            'postDir': os.path.join(os.getcwd(), 'mantispostdir'),
             'title': 'The mantis has you!',
         }
         settings = BlaskSettings(**kwsettings)

--- a/tests/testsettings.py
+++ b/tests/testsettings.py
@@ -1,18 +1,18 @@
-from pathlib import Path
+import os
 
-BASE_DIR = Path(__file__).resolve().parents[0]
+BASE_DIR = os.getcwd()
 
 # Templates directory
-templateDir = BASE_DIR / 'templates'
+templateDir = os.path.join(BASE_DIR, 'templates')
 
 # Posts directory
-postDir = BASE_DIR / 'posts2'
+postDir = os.path.join(BASE_DIR, 'posts')
 
 # Default layout template
 defaultLayout = "template.html"
 
 # Static files directory
-staticDir = BASE_DIR / 'static'
+staticDir = os.path.join(BASE_DIR, 'static')
 
 # Website title
 title = 'The mantis revenge!'

--- a/tests/testsettings.py
+++ b/tests/testsettings.py
@@ -1,18 +1,18 @@
-import os
+from pathlib import Path
 
-BASE_DIR = os.getcwd()
+BASE_DIR = Path(__file__).resolve().parents[0]
 
 # Templates directory
-templateDir = os.path.join(BASE_DIR, 'templates')
+templateDir = BASE_DIR / 'templates'
 
 # Posts directory
-postDir = os.path.join(BASE_DIR, 'posts2')
+postDir = BASE_DIR / 'posts2'
 
 # Default layout template
 defaultLayout = "template.html"
 
 # Static files directory
-staticDir = os.path.join(BASE_DIR, 'static')
+staticDir = BASE_DIR / 'static'
 
 # Website title
 title = 'The mantis revenge!'


### PR DESCRIPTION
I have modified .gitignore to ignore Visual Studio Code files, SonarLint extension of VSCode files and DS_Store files of Mac OS.

I have changed the old way to work with paths `os.path`to the modern pythonic way `pathlib`in settings.py and setup.py