### PR TITLE
issue 45-46 Blask/blasksettings.py

### DIFF
--- a/Blask/blasksettings.py
+++ b/Blask/blasksettings.py
@@ -41,8 +41,10 @@ class BlaskSettings(object):
 
     def __init__(self, *args, **kwargs):
         """
-        Initialice the Blask Settigns. First, look for the BLASK_SETTINGS enviroment variable and try to load the module.
-        If there is not environment variable, try to load the current settings from the default values.
+        Initialice the Blask Settigns. First, look for the BLASK_SETTINGS enviroment variable 
+        and try to load the module.
+        If there is not environment variable, try to load the current settings from the 
+        default values.
         :param args:
         :param kwargs:
         """


### PR DESCRIPTION
1. Blask/blasksettings.py:45:0: C0301: Line too long (121/100) (line-too-long)
2. Blask/blasksettings.py:46:0: C0301: Line too long (103/100) (line-too-long)

**solved issue 45,46 of Blask/blasksettings.py** 