### PR TITLE
Fixing Github Actions Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           sonar-scanner \
             -Dsonar.login=$SONAR_TOKEN \
-            -Dsonar.projectKey=SebGoliot_blask \
+            -Dsonar.projectKey=blask-project-key \
             -Dsonar.sources=blask/ \
-            -Dsonar.organization=sebgoliot-org \
+            -Dsonar.organization=zerasul-github \
             -Dsonar.python.coverage.reportPaths=coverage.xml \
             -Dsonar.projectName=Blask \
             -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env: 
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
@@ -24,11 +25,12 @@ jobs:
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
       - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v1
+        uses: warchant/setup-sonar-scanner@v3
 
       - name: pip install
         run : |
             pip install pipenv
+            pipenv install importlib-metadata
             pipenv install --dev
             pip install pylint
 
@@ -39,4 +41,12 @@ jobs:
         run : pipenv run linter
 
       - name: Sonar cube
-        run: sonar-scanner -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=blask-project-key -Dsonar.sources=Blask/ -Dsonar.organization=zerasul-github -Dsonar.python.coverage.reportPaths=coverage.xml -Dsonar.projectName=Blask
+        run: |
+          sonar-scanner \
+            -Dsonar.login=$SONAR_TOKEN \
+            -Dsonar.projectKey=SebGoliot_blask \
+            -Dsonar.sources=blask/ \
+            -Dsonar.organization=sebgoliot-org \
+            -Dsonar.python.coverage.reportPaths=coverage.xml \
+            -Dsonar.projectName=Blask \
+            -Dsonar.host.url=https://sonarcloud.io

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ pytest-cov = ">=2.7.1"
 pytest-mock = ">=1.10.4"
 
 [requires]
-python_version = "python 3.7"
+python_version = "3.7"
 
 [scripts]
 


### PR DESCRIPTION
This fixes the issue #221 

- `GITHUB_TOKEN` was missing
- `ubuntu-latest` is missing the `importlib-metadata` package, as it is not required since Python 3.8
- `Dsonar.host.url` was missing
- `Dsonar.sources` had a typo (`Blask` instead of `blask`)
- Updated the `setup-sonar-scanner` action to v3

I also had to edit the pipfile, changed the python version from `python 3.7` to `3.7`,
But it may be a good idea to set it to `3`, as it should solve the issue #220 (see #222)
