### PR TITLE
[Fix] (Search engine) Avoid sorting elements withdout date defined

### DIFF
--- a/blask/blogrenderer.py
+++ b/blask/blogrenderer.py
@@ -140,7 +140,7 @@ class BlogRenderer:
             notdateredentries = list(
                 filter(lambda d: d.date is not None, entries))
             entries = list(
-                sorted(dateredentries, key=lambda t: t.date, reverse=True))
+               sorted(dateredentries, key=lambda t: t.date is not None, reverse=True))
             entries.extend(notdateredentries)
         return entries
 

--- a/tests/blogrender_test.py
+++ b/tests/blogrender_test.py
@@ -49,9 +49,9 @@ class TestblogRender:
 
     def test_search(self):
         entries = self.blogrender.list_posts(search="documentation")
-        assert len(entries) == 1
+        assert len(entries) == 2
         entrieslist = self.blogrender.generatetagpage(entries)
-        assert "href='/docs'" in entrieslist
+        assert "href='/./docs'" in entrieslist
 
     def test_str(self):
         entry = self.blogrender.renderfile("index")


### PR DESCRIPTION
Some pages or posts has not a date defined, so sorting key is invalid. This pull request fixes just avoiding non-dated posts on the lambda expression.